### PR TITLE
fix: Component loading on case-sensitive filesystems

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import "./App.css"
-import Multisig from "./components/multisig"
+import Multisig from "./components/Multisig"
 import Single from "./components/Single"
 import Mnemonic from "./components/Mnemonic"
 import Convert from "./components/Convert"


### PR DESCRIPTION
App wouldn't start for me on Linux (which is more sensitive to case than Windows or OSX), and I had to change the case of one of the components to get it to work